### PR TITLE
build(frontend): Elimina docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,0 @@
-version: '3.9'
-services:
-  frontend:
-    build: .
-    ports:
-      - "80:80"
-    restart: always


### PR DESCRIPTION
Simplifica la configuración al delegar orquestación al proyecto raíz.